### PR TITLE
fix lower price higher than upper price

### DIFF
--- a/demeter/uniswap/market.py
+++ b/demeter/uniswap/market.py
@@ -407,6 +407,7 @@ class UniLpMarket(Market):
                                                                                               upper_tick,
                                                                                               sqrt_price_x96)
         base_used, quote_used = self._convert_pair(token0_used, token1_used)
+        lower_tick, upper_tick = self._convert_pair(upper_tick, lower_tick)
         self.record_action(AddLiquidityAction(
             market=self.market_info,
             base_balance_after=self.broker.get_token_balance_with_unit(self.base_token),


### PR DESCRIPTION
When adding liquidity by ticks the lower price is the upper price and vice versa in the record action.
By converting the tick pair the prices are right. 
This does not happen when adding liquidity by price because the code doesn't use the tick to calculate the price, it passes the input prices.