### PR TITLE
Change fee calc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "*test*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/demeter/uniswap/core.py
+++ b/demeter/uniswap/core.py
@@ -94,7 +94,6 @@ class V3CoreLib(object):
                 share = Decimal(position.liquidity) / Decimal(state.current_liquidity)
             position.pending_amount0 += from_wei(state.in_amount0, pool.token0.decimal) * share * pool.fee_rate
             position.pending_amount1 += from_wei(state.in_amount1, pool.token1.decimal) * share * pool.fee_rate
-        
         condition_in_position = pos.upper_tick >= state.current_tick >= pos.lower_tick
         condition_over_position = (prev_current_tick > pos.upper_tick and state.current_tick < pos.lower_tick) or (state.current_tick > pos.upper_tick and prev_current_tick < pos.lower_tick)
         condition_in_to_out_position = pos.upper_tick >= prev_current_tick >= pos.lower_tick and (state.current_tick > pos.upper_tick or state.current_tick < pos.lower_tick)

--- a/demeter/uniswap/core.py
+++ b/demeter/uniswap/core.py
@@ -77,7 +77,7 @@ class V3CoreLib(object):
         return lower_tick, upper_tick
 
     @staticmethod
-    def update_fee(pool: UniV3Pool, pos: PositionInfo, position: Position, state: UniV3PoolStatus):
+    def update_fee(pool: UniV3Pool, pos: PositionInfo, position: Position, state: UniV3PoolStatus, prev_current_tick: int):
         """
         update fee
         :param pool: operation on which pool
@@ -87,11 +87,17 @@ class V3CoreLib(object):
         :return: None
         """
         # in most cases, tick will not cross to on_bar one, which means L will not change.
-        if pos.upper_tick > state.current_tick > pos.lower_tick:
-            # if the simulating liquidity is above the actual liquidity, we will consider share=1
+        def calc_amounts():
             if position.liquidity >= state.current_liquidity:
                 share = Decimal(1)
             else:
                 share = Decimal(position.liquidity) / Decimal(state.current_liquidity)
             position.pending_amount0 += from_wei(state.in_amount0, pool.token0.decimal) * share * pool.fee_rate
             position.pending_amount1 += from_wei(state.in_amount1, pool.token1.decimal) * share * pool.fee_rate
+        
+        condition_in_position = pos.upper_tick > state.current_tick > pos.lower_tick
+        condition_over_position = (prev_current_tick > pos.upper_tick and state.current_tick < pos.lower_tick) or (state.current_tick > pos.upper_tick and prev_current_tick < pos.lower_tick)
+        condition_in_to_out_position = pos.upper_tick > prev_current_tick > pos.lower_tick and (state.current_tick > pos.upper_tick or state.current_tick < pos.lower_tick)
+        
+        if condition_in_position or condition_over_position or condition_in_to_out_position:
+            calc_amounts()

--- a/demeter/uniswap/core.py
+++ b/demeter/uniswap/core.py
@@ -95,9 +95,9 @@ class V3CoreLib(object):
             position.pending_amount0 += from_wei(state.in_amount0, pool.token0.decimal) * share * pool.fee_rate
             position.pending_amount1 += from_wei(state.in_amount1, pool.token1.decimal) * share * pool.fee_rate
         
-        condition_in_position = pos.upper_tick > state.current_tick > pos.lower_tick
+        condition_in_position = pos.upper_tick >= state.current_tick >= pos.lower_tick
         condition_over_position = (prev_current_tick > pos.upper_tick and state.current_tick < pos.lower_tick) or (state.current_tick > pos.upper_tick and prev_current_tick < pos.lower_tick)
-        condition_in_to_out_position = pos.upper_tick > prev_current_tick > pos.lower_tick and (state.current_tick > pos.upper_tick or state.current_tick < pos.lower_tick)
+        condition_in_to_out_position = pos.upper_tick >= prev_current_tick >= pos.lower_tick and (state.current_tick > pos.upper_tick or state.current_tick < pos.lower_tick)
         
         if condition_in_position or condition_over_position or condition_in_to_out_position:
             calc_amounts()

--- a/demeter/uniswap/market.py
+++ b/demeter/uniswap/market.py
@@ -116,8 +116,9 @@ class UniLpMarket(Market):
 
     # endregion
 
-    def set_market_status(self, timestamp: datetime | None, data: pd.Series | UniV3PoolStatus, price: pd.Series):
+    def set_market_status(self, timestamp: datetime | None, data: pd.Series | UniV3PoolStatus, price: pd.Series | None):
         # update price tick
+        self.prev_tick = self._market_status.current_tick
         if isinstance(data, UniV3PoolStatus):
             self._market_status = data
         else:
@@ -174,7 +175,7 @@ class UniLpMarket(Market):
         fee will be calculated by liquidity
         """
         for position_info, position in self._positions.items():
-            V3CoreLib.update_fee(self.pool_info, position_info, position, self.market_status)
+            V3CoreLib.update_fee(self.pool_info, position_info, position, self.market_status, self.prev_tick)
 
     def get_market_balance(self, prices: pd.Series | Dict[str, Decimal] = None) -> MarketBalance:
         """

--- a/tests/uni_lp_market_test_token1_is_base.py
+++ b/tests/uni_lp_market_test_token1_is_base.py
@@ -28,7 +28,7 @@ class TestUniLpMarketToken1Base(unittest.TestCase):
                                                        1107562474636574291,
                                                        18714189922,
                                                        58280013108171131649,
-                                                       price))
+                                                       price), None)
 
         broker.set_balance(self.eth, 1)
         broker.set_balance(self.usdc, price)
@@ -104,13 +104,152 @@ class TestUniLpMarketToken1Base(unittest.TestCase):
         #                    usdc_amount])
         price = market.tick_to_price(market.market_status.current_tick)
         market.set_market_status(None, UniV3PoolStatus(None, market.market_status.current_tick, liquidity * 100,
-                                                       eth_amount, usdc_amount, price))
+                                                       eth_amount, usdc_amount, price), None)
         market.update()
         print("=========after a bar======================================================================")
         TestUniLpMarketToken1Base.print_broker(broker)
 
         self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount0)
         self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount1)
+
+        fee0 = market.position(new_position).pending_amount0
+        fee1 = market.position(new_position).pending_amount1
+        balance0 = broker.assets[self.eth].balance
+        balance1 = broker.assets[self.usdc].balance
+        market.collect_fee(new_position)
+        print("=========collect======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+        self.assertEqual(fee0 + balance0, broker.assets[self.eth].balance)
+        self.assertEqual(fee1 + balance1, broker.assets[self.usdc].balance)
+        self.assertEqual(market.positions[new_position].pending_amount0, 0)
+
+    def test_collect_fee_down(self):
+        broker = self.get_broker()
+        market: UniLpMarket = broker.markets[test_market]
+        
+        (new_position, base_used, quote_used, liquidity) = market._add_liquidity_by_tick(Decimal(1),
+                                                                                         market.market_status.price,
+                                                                                         market.market_status.current_tick - 100,
+                                                                                         market.market_status.current_tick - 10)
+        TestUniLpMarketToken1Base.print_broker(broker)
+        eth_amount = 10000000000000000000
+        usdc_amount = 10000000
+        current = market.market_status.current_tick
+        price = market.tick_to_price(market.market_status.current_tick)
+        market.set_market_status(None, UniV3PoolStatus(None, current-120, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.set_market_status(None, UniV3PoolStatus(None, current, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.update()
+        print("=========after a bar======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount0)
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount1)
+
+        fee0 = market.position(new_position).pending_amount0
+        fee1 = market.position(new_position).pending_amount1
+        balance0 = broker.assets[self.eth].balance
+        balance1 = broker.assets[self.usdc].balance
+        market.collect_fee(new_position)
+        print("=========collect======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+        self.assertEqual(fee0 + balance0, broker.assets[self.eth].balance)
+        self.assertEqual(fee1 + balance1, broker.assets[self.usdc].balance)
+        self.assertEqual(market.positions[new_position].pending_amount0, 0)
+
+
+    def test_collect_fee_in_out(self):
+        broker = self.get_broker()
+        market: UniLpMarket = broker.markets[test_market]
+        (new_position, base_used, quote_used, liquidity) = market._add_liquidity_by_tick(Decimal(1),
+                                                                                         market.market_status.price,
+                                                                                         market.market_status.current_tick - 100,
+                                                                                         market.market_status.current_tick - 10)
+        TestUniLpMarketToken1Base.print_broker(broker)
+        eth_amount = 10000000000000000000
+        usdc_amount = 10000000
+
+        current = market.market_status.current_tick
+        price = market.tick_to_price(market.market_status.current_tick)
+        market.set_market_status(None, UniV3PoolStatus(None, current-50, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.set_market_status(None, UniV3PoolStatus(None, current, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.update()
+        print("=========after a bar======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount0)
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount1)
+
+        fee0 = market.position(new_position).pending_amount0
+        fee1 = market.position(new_position).pending_amount1
+        balance0 = broker.assets[self.eth].balance
+        balance1 = broker.assets[self.usdc].balance
+        market.collect_fee(new_position)
+        print("=========collect======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+        self.assertEqual(fee0 + balance0, broker.assets[self.eth].balance)
+        self.assertEqual(fee1 + balance1, broker.assets[self.usdc].balance)
+        self.assertEqual(market.positions[new_position].pending_amount0, 0)
+
+
+    def test_collect_fee_up(self):
+        broker = self.get_broker()
+        market: UniLpMarket = broker.markets[test_market]
+        (new_position, base_used, quote_used, liquidity) = market._add_liquidity_by_tick(Decimal(1),
+                                                                                         market.market_status.price,
+                                                                                         market.market_status.current_tick - 100,
+                                                                                         market.market_status.current_tick - 10)
+        TestUniLpMarketToken1Base.print_broker(broker)
+        eth_amount = 10000000000000000000
+        usdc_amount = 10000000
+
+        price = market.tick_to_price(market.market_status.current_tick)
+        market.set_market_status(None, UniV3PoolStatus(None, market.market_status.current_tick, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.set_market_status(None, UniV3PoolStatus(None, market.market_status.current_tick - 120, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.update()
+        print("=========after a bar======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount0)
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount1)
+
+        fee0 = market.position(new_position).pending_amount0
+        fee1 = market.position(new_position).pending_amount1
+        balance0 = broker.assets[self.eth].balance
+        balance1 = broker.assets[self.usdc].balance
+        market.collect_fee(new_position)
+        print("=========collect======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+        self.assertEqual(fee0 + balance0, broker.assets[self.eth].balance)
+        self.assertEqual(fee1 + balance1, broker.assets[self.usdc].balance)
+        self.assertEqual(market.positions[new_position].pending_amount0, 0)
+
+    def test_collect_fee_no_fee(self):
+        broker = self.get_broker()
+        market: UniLpMarket = broker.markets[test_market]        
+        (new_position, base_used, quote_used, liquidity) = market._add_liquidity_by_tick(Decimal(1),
+                                                                                         market.market_status.price,
+                                                                                         market.market_status.current_tick - 100,
+                                                                                         market.market_status.current_tick - 10)
+        TestUniLpMarketToken1Base.print_broker(broker)
+        eth_amount = 10000000000000000000
+        usdc_amount = 10000000
+        price = market.tick_to_price(market.market_status.current_tick)
+        market.set_market_status(None, UniV3PoolStatus(None, market.market_status.current_tick - 110, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.set_market_status(None, UniV3PoolStatus(None, market.market_status.current_tick - 120, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.update()
+        print("=========after a bar======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+
+        self.assertTrue(Decimal("0") == market.position(new_position).pending_amount0)
+        self.assertTrue(Decimal("0") == market.position(new_position).pending_amount1)
 
         fee0 = market.position(new_position).pending_amount0
         fee1 = market.position(new_position).pending_amount1

--- a/tests/uni_lp_market_test_token1_is_base.py
+++ b/tests/uni_lp_market_test_token1_is_base.py
@@ -194,7 +194,6 @@ class TestUniLpMarketToken1Base(unittest.TestCase):
         self.assertEqual(fee1 + balance1, broker.assets[self.usdc].balance)
         self.assertEqual(market.positions[new_position].pending_amount0, 0)
 
-
     def test_collect_fee_up(self):
         broker = self.get_broker()
         market: UniLpMarket = broker.markets[test_market]
@@ -261,6 +260,42 @@ class TestUniLpMarketToken1Base(unittest.TestCase):
         self.assertEqual(fee0 + balance0, broker.assets[self.eth].balance)
         self.assertEqual(fee1 + balance1, broker.assets[self.usdc].balance)
         self.assertEqual(market.positions[new_position].pending_amount0, 0)
+
+    def test_collect_fee_same_tick(self):
+        broker = self.get_broker()
+        market: UniLpMarket = broker.markets[test_market]
+        current_tick = market.market_status.current_tick
+        (new_position, base_used, quote_used, liquidity) = market._add_liquidity_by_tick(Decimal(1),
+                                                                                         market.market_status.price,
+                                                                                         current_tick - 100,
+                                                                                         current_tick - 10)
+        TestUniLpMarketToken1Base.print_broker(broker)
+        eth_amount = 10000000000000000000
+        usdc_amount = 10000000
+
+        price = market.tick_to_price(current_tick)
+        market.set_market_status(None, UniV3PoolStatus(None, current_tick, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.set_market_status(None, UniV3PoolStatus(None, current_tick - 100, liquidity * 100,
+                                                       eth_amount, usdc_amount, price), None)
+        market.update()
+        print("=========after a bar======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount0)
+        self.assertTrue(Decimal("0.00005") == market.position(new_position).pending_amount1)
+
+        fee0 = market.position(new_position).pending_amount0
+        fee1 = market.position(new_position).pending_amount1
+        balance0 = broker.assets[self.eth].balance
+        balance1 = broker.assets[self.usdc].balance
+        market.collect_fee(new_position)
+        print("=========collect======================================================================")
+        TestUniLpMarketToken1Base.print_broker(broker)
+        self.assertEqual(fee0 + balance0, broker.assets[self.eth].balance)
+        self.assertEqual(fee1 + balance1, broker.assets[self.usdc].balance)
+        self.assertEqual(market.positions[new_position].pending_amount0, 0)
+
 
     def test_buy(self):
         broker = self.get_broker()


### PR DESCRIPTION
This PR adds logic to fee updates to collect fees for more cases than the current state (only on swap ends between position):
* When the swap start in a higher tick of the upper position and ends in a lower tick than the lower position (or the opposite - start at lower and finish in higher)
* When swap starts between the position and ends outside the position

* Fix broken tests 
